### PR TITLE
p4rt: Parse p4info file to get table details

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Build strongSwan
 
 After successful build, files will be installed in `./output_strongswan` directory.
 
-Compile IPsec P4 files and generate the P4 artifacts (p4info.txt and ipsec.pb.bin). These will be used to set the P4 pipeline. See the [Compiling P4 Programs guide](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/es2k/compiling-p4-programs.md) for details.
+Compile IPsec P4 files and generate the P4 artifacts (p4info.txt and ipsec.pb.bin). These will be used to set the P4 pipeline. See the [Compiling P4 Programs guide](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/es2k/compiling-p4-programs.md) for details. Copy the P4 artifacts (p4info.txt and ipsec.pb.bin) in `/var/tmp/` dir with file name linux_networking.p4info.txt and ipsec_fixed_func.pb.bin.
 
 Generate and install the keys and certificates for TLS authentication. Detailed instructions can be found in the [Generating and Installing TLS Certificates guide](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/security/using-tls-certificates.md). The keys and certificates will need to be copied to `/usr/share/stratum/certs` folder.
 
 Configure strongSwan
-* Review the server IP addresses, client certificate filename, client key filename, and client CA filename in `ipsec_offload_plugin/ipsec_offload.conf` file.
+* Review the server IP addresses, client certificate filename, client key filename, client CA filename and p4 table/action names (as per p4info.txt file) in `ipsec_offload_plugin/ipsec_offload.conf` file.
 * Copy the configuration file to `/usr/share/stratum`
 * Update the strongSwan configuration files (eg: swanctl.conf). Please refer strongSwan documentation.
 * Update the system date and stop StrongSwan service (systemctl stop strongswan.service)

--- a/ipsec_offload_plugin/ipsec_offload.conf
+++ b/ipsec_offload_plugin/ipsec_offload.conf
@@ -4,3 +4,19 @@ p4rt_server=localhost:9559
 cli_cert=/usr/share/stratum/certs/client.crt
 cli_key=/usr/share/stratum/certs/client.key
 ca_cert=/usr/share/stratum/certs/ca.crt
+
+# P4 table and action names as per p4info file
+tx_spd=crypto_tunnel_control.ipsec_tx_spd_table
+tx_sa_classification=crypto_tunnel_control.ipsec_tx_sa_classification_table
+rx_sa_classification=MainControlDecrypt.ipsec_rx_sa_classification_table
+encap_mod=crypto_tunnel_control.outer_ipv4_encap_mod_table
+decap_mod=crypto_tunnel_control.outer_ipv4_decap_mod_table
+post_decrypt=crypto_tunnel_control.ipsec_rx_post_decrypt_table
+
+tx_transport_action=crypto_tunnel_control.ipsec_tx_transport
+tx_tunnel_action=crypto_tunnel_control.ipsec_tx_tunnel
+rx_tunnel_action=MainControlDecrypt.ipsec_decrypt
+protect_action=crypto_tunnel_control.ipsec_protect
+encap_mod_action=crypto_tunnel_control.encap_outer_ipv4_mod
+decap_mod_action=crypto_tunnel_control.decap_outer_ipv4_mod
+rx_post_decrypt_action=crypto_tunnel_control.ipsec_tunnel_post_decrypt

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_grpc_connect.cc
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_grpc_connect.cc
@@ -105,6 +105,7 @@ enum ipsec_status gnmi_init() {
 	     else if (name == GNMI_CA_CERT_PATH)
 	         gnmi_ctx.ca_cert = value;
          }
+	 cFile.close();
      }
      else
      {
@@ -254,6 +255,7 @@ static void BuildGnmiDeletePath(::gnmi::Path* path, int offloadid, bool inbound)
       ::gnmi::GetResponse resp;
       Status status = stub->Get(&ctx, req, &resp);
       if(status.ok()) {
+        LOGGER->Log("DEBUG: Got gnmi resp for GnmiGetSPI \n" + resp.DebugString());
         *spi = resp.mutable_notification(0)->mutable_update(0)->mutable_val()->uint_val();
         return true;
       } else {

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
@@ -358,6 +358,7 @@ void *audit_log_poll(void *arg) {
 		 * enable it using ipsec_subscribe_audit_log() and remove this check.
 		 */
 		if (!subscribe_audit_done) {
+			DBG2(DBG_KNL, "subscribe to audit log notification not done!\n");
 			sleep(1);
 			continue;
 		}
@@ -897,5 +898,6 @@ ipsec_offload_t *ipsec_offload_create()
 	this->close = false;
 	ipsec_auto_config_init(&this->thread_id, &this->close);
 //	ipsec->events->register_listener(ipsec->events, &this->ipsec_listener);
+	DBG1(DBG_KNL, "p4rt and gnmi init Done \n");
 	return &this->public;
 };


### PR DESCRIPTION
  - Read the table names from config file and parse p4info to get table ID dynamically.
  - Add debug logs.
  - Update README for these changes.
  
Signed-off-by: Vinay Kumar Yadav <vinay.kumar.yadav@intel.com>