### PR TITLE
Add support for VXLAN+IPSEC combined usecase

### DIFF
--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
@@ -62,6 +62,8 @@ enum ipsec_status ipsec_spd_table(enum ipsec_table_op table_op,
                                                 uint8_t proto,
 						uint32_t offload_id);
 enum ipsec_status ipsec_tx_sa_classification_table(enum ipsec_table_op table_op,
+						char outer_dst_ip_addr[16],
+						char outer_src_ip_addr[16],
 						char dst_ip_addr[16],
 						char src_ip_addr[16],
 						char crypto_offload,
@@ -802,6 +804,7 @@ METHOD(kernel_ipsec_t, add_policy, status_t,
                 }
 
 		err = ipsec_tx_sa_classification_table(IPSEC_TABLE_ADD,
+							   dst_outer, src_outer,
 						       dst, src, 1,
 						       offload_id, offload_id,
 						       id->src_ts->get_protocol(id->src_ts),
@@ -811,6 +814,7 @@ METHOD(kernel_ipsec_t, add_policy, status_t,
 			     "add entry failed for underlay");
 		} else if (err == IPSEC_DUP_ENTRY) {
 			err = ipsec_tx_sa_classification_table(IPSEC_TABLE_MOD,
+								   dst_outer, src_outer,
 							       dst, src, 1,
 							       offload_id, offload_id,
 							       id->src_ts->get_protocol(id->src_ts),
@@ -825,6 +829,7 @@ METHOD(kernel_ipsec_t, add_policy, status_t,
 			DBG2(DBG_KNL, "ipsec_tx_sa_classification_table add entry done for underlay");
 
                 err = ipsec_tx_sa_classification_table(IPSEC_TABLE_ADD,
+													   dst_outer, src_outer,
                                                        dst, src, 1,
                                                        offload_id, offload_id,
                                                        id->src_ts->get_protocol(id->src_ts),
@@ -834,6 +839,7 @@ METHOD(kernel_ipsec_t, add_policy, status_t,
                              "add entry failed for non underlay");
                 } else if (err == IPSEC_DUP_ENTRY) {
                         err = ipsec_tx_sa_classification_table(IPSEC_TABLE_MOD,
+															   dst_outer, src_outer,
                                                                dst, src, 1,
                                                                offload_id, offload_id,
                                                                id->src_ts->get_protocol(id->src_ts),
@@ -958,6 +964,7 @@ METHOD(kernel_ipsec_t, del_policy, status_t,
 		if (!reqid_bitget(data->sa->reqid)) {
 			/* for Tx table dst = src in inbound */
 			err = ipsec_tx_sa_classification_table(IPSEC_TABLE_DEL,
+								   src_outer, dst_outer,
 							       src, dst, 1,
 							       offload_id, offload_id,
 							       id->src_ts->get_protocol(id->src_ts),
@@ -967,6 +974,7 @@ METHOD(kernel_ipsec_t, del_policy, status_t,
 				     "del entry failed");
 
                         err = ipsec_tx_sa_classification_table(IPSEC_TABLE_DEL,
+															   src_outer, dst_outer,
                                                                src, dst, 1,
                                                                offload_id, offload_id,
                                                                id->src_ts->get_protocol(id->src_ts),

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
@@ -1,6 +1,6 @@
 /******************************************************************
  ******************************************************************
- * Copyright (C) 2000-2002, 2004-2017, 2021-2022 Intel Corporation.
+ * Copyright (C) 2000-2002, 2004-2017, 2021-2024 Intel Corporation.
  *
  *This file is part of ipsec-offload plugin from strongswan.
  *This program is free software; you can redistribute it and/or 
@@ -97,6 +97,9 @@ enum ipsec_status ipsec_outer_ipv4_decap_mod_table(
 enum ipsec_status ipsec_tunnel_id_table(enum ipsec_table_op table_op,
                                         uint32_t tunnel_id);
 #define SPI_MAX_LIMIT 0xffffff
+
+#define PROTO_IP 4
+
 struct private_ipsec_offload_t {
 
 	/**
@@ -848,7 +851,7 @@ METHOD(kernel_ipsec_t, add_policy, status_t,
 			err = ipsec_outer_ipv4_encap_mod_table(IPSEC_TABLE_ADD,
 							       offload_id,
 							       src_outer, dst_outer,
-							       id->src_ts->get_protocol(id->src_ts),
+							       PROTO_IP, // proto should be 0x04 in tunnel mode for encap_mod_table
 							       inner_smac, inner_dmac);
 			if(err != IPSEC_SUCCESS)
 				DBG2(DBG_KNL, "Inline_crypto_ipsec add_with_encap_outer_ipv4_mod:"
@@ -980,7 +983,7 @@ METHOD(kernel_ipsec_t, del_policy, status_t,
 			
 			err = ipsec_outer_ipv4_encap_mod_table(IPSEC_TABLE_DEL,
 							       offload_id, dst_outer, src_outer,
-							       id->src_ts->get_protocol(id->src_ts),
+							       PROTO_IP, // proto should be 0x04 in tunnel mode for encap_mod_table
 							       inner_smac, inner_dmac);
 			if(err != IPSEC_SUCCESS)
 				DBG2(DBG_KNL, "Inline_crypto_ipsec del_with_encap_outer_ipv4_mod:"

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload.c
@@ -741,7 +741,7 @@ METHOD(kernel_ipsec_t, add_policy, status_t,
 			err = ipsec_rx_post_decrypt_table(IPSEC_TABLE_ADD,
 							  0, 0, 2 /*As of now SAD table programs req-id a 2 hence changing it to 2.
 							  This can be changed to offload id once map ingress SPI to egress*/,
-							  src, dst, offload_id);
+							  src_outer, dst_outer, offload_id);
 			if(err == IPSEC_FAILURE) {
 				DBG2(DBG_KNL, "Inline_crypto_ipsec ipsec_rx_post_decrypt_tabl:"
 				     "add entry failed err_code[ %d]", err);
@@ -749,7 +749,7 @@ METHOD(kernel_ipsec_t, add_policy, status_t,
 				err = ipsec_rx_post_decrypt_table(IPSEC_TABLE_MOD,
 								  0, 0, 2 /*As of now SAD table programs req-id a 2 hence changing it to 2.
 								  This can be changed to offload id once map ingress SPI to egress*/,
-								  src, dst, offload_id);
+								  src_outer, dst_outer, offload_id);
 				if(err == IPSEC_FAILURE) {
 					DBG2(DBG_KNL, "ipsec_rx_post_decrypt_table: modify entry failed");
 				}

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_p4rt_client.cc
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_p4rt_client.cc
@@ -64,6 +64,8 @@ extern "C" enum ipsec_status ipsec_spd_table(enum ipsec_table_op table_op,
 						uint32_t offload_id);
 extern "C" enum ipsec_status ipsec_tx_sa_classification_table(
 						enum ipsec_table_op table_op,
+						char outer_dst_ip_addr[16],
+						char outer_src_ip_addr[16],
 						char dst_ip_addr[16],
 						char src_ip_addr[16],
 						char crypto_offload,
@@ -615,6 +617,8 @@ class IPSecP4RuntimeClient {
 		}
 
 		enum ipsec_status P4runtimeIpsecTxSaClassificationTable(enum ipsec_table_op table_op,
+									char outer_dst_ip_addr[16],
+									char outer_src_ip_addr[16],
 									char dst_ip_addr[16],
 									char src_ip_addr[16],
 									char crypto_offload,
@@ -665,7 +669,7 @@ class IPSecP4RuntimeClient {
 					table_entry.mutable_action()->mutable_action()->set_action_id(tunnel_action_id);
 					params = table_entry.mutable_action()->mutable_action()->add_params();
 					params->set_param_id(1);
-					params->set_value(convert_ip_to_str(dst_ip_addr));
+					params->set_value(convert_ip_to_str(outer_dst_ip_addr));
 					update->set_type(p4::v1::Update::INSERT);
 				} else {
                                         if(is_underlay) {
@@ -686,7 +690,7 @@ class IPSecP4RuntimeClient {
 					table_entry.mutable_action()->mutable_action()->set_action_id(tunnel_action_id);
 					params = table_entry.mutable_action()->mutable_action()->add_params();
 					params->set_param_id(1);
-					params->set_value(convert_ip_to_str(dst_ip_addr));
+					params->set_value(convert_ip_to_str(outer_dst_ip_addr));
 					update->set_type(p4::v1::Update::MODIFY);
 				} else {
                                         if(is_underlay) {
@@ -1066,7 +1070,9 @@ enum ipsec_status ipsec_spd_table(enum ipsec_table_op table_op,
 }
 
 enum ipsec_status ipsec_tx_sa_classification_table(enum ipsec_table_op table_op,
-						   char dst_ip_addr[16],
+												   char outer_dst_ip_addr[16],
+												   char outer_src_ip_addr[16],
+						   						   char dst_ip_addr[16],
                                                    char src_ip_addr[16],
                                                    char crypto_offload,
                                                    uint32_t offloadid,
@@ -1076,12 +1082,14 @@ enum ipsec_status ipsec_tx_sa_classification_table(enum ipsec_table_op table_op,
 						   bool is_underlay) {
 	IPSecP4RuntimeClient client(p4rt_ctx.p4rt_server_addr);
         return client.P4runtimeIpsecTxSaClassificationTable(table_op,
+															outer_dst_ip_addr,
+															outer_src_ip_addr,
                                	                            dst_ip_addr,
                                      	                    src_ip_addr,
                                                	            crypto_offload,
                                                        	    offloadid,
-	                                                    tunnel_id,
-        	                                            proto,
+	                                                    	tunnel_id,
+        	                                            	proto,
                                                             tunnel_mode,
 							    is_underlay);
 }


### PR DESCRIPTION
We need to program ipsec_tx_sa_classification table to cover both vxlan(underlay) and non-vxlan(underlay) case.