### PR TITLE
Remove set -e from bash script

### DIFF
--- a/env_setup_acc.sh
+++ b/env_setup_acc.sh
@@ -6,8 +6,6 @@
 # Script to setup environment variables facilitating ipsec-recipe compilation
 #
 
-set -e
-
 # Define directories
 DEPS_INSTALL=$PWD/"PLUGIN_DEP_INSTALL"
 DEPS_SRC=$PWD/"PLUGIN_DEP_SRC"


### PR DESCRIPTION
The `set -e` in the script causes the shell's bash-completion to terminate the session due to unhandled error. Removing the command from the script

More info on this problem here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=668265

