### PR TITLE
Apply clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+BasedOnStyle:  Google
+---
+Language:               Cpp
+DerivePointerAlignment: false
+PointerAlignment:       Left
+---
+Language:      TextProto
+BasedOnStyle:  Google
+DisableFormat: true
+...

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_grpc_connect.h
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_grpc_connect.h
@@ -1,4 +1,4 @@
-// Copyright 2000-2002, 2004-2017, 2021-2023 Intel Corporation
+// Copyright 2000-2002, 2004-2017, 2021-2023, 2025 Intel Corporation
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef IPSEC_GRPC_CONNECT_H_
@@ -8,16 +8,8 @@
 #define INVALID_SA 0x1000000
 #define INVALID_INIT_SA 0x1000001
 
-enum ipsec_status {
-	IPSEC_SUCCESS,
-	IPSEC_DUP_ENTRY,
-	IPSEC_FAILURE=-1
-};
+enum ipsec_status { IPSEC_SUCCESS, IPSEC_DUP_ENTRY, IPSEC_FAILURE = -1 };
 
-enum ipsec_table_op {
-	IPSEC_TABLE_ADD,
-	IPSEC_TABLE_MOD,
-	IPSEC_TABLE_DEL
-};
+enum ipsec_table_op { IPSEC_TABLE_ADD, IPSEC_TABLE_MOD, IPSEC_TABLE_DEL };
 
 #endif // IPSEC_GRPC_CONNECT_H_

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_grpc_connect.h
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_grpc_connect.h
@@ -12,4 +12,4 @@ enum ipsec_status { IPSEC_SUCCESS, IPSEC_DUP_ENTRY, IPSEC_FAILURE = -1 };
 
 enum ipsec_table_op { IPSEC_TABLE_ADD, IPSEC_TABLE_MOD, IPSEC_TABLE_DEL };
 
-#endif // IPSEC_GRPC_CONNECT_H_
+#endif  // IPSEC_GRPC_CONNECT_H_

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload.h
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload.h
@@ -1,28 +1,28 @@
-// Copyright 2000-2002, 2004-2017, 2021-2023 Intel Corporation
+// Copyright 2000-2002, 2004-2017, 2021-2023, 2025 Intel Corporation
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef IPSEC_OFFLOAD_H_
 #define IPSEC_OFFLOAD_H_
 
-#include <library.h>
-#include <kernel/kernel_ipsec.h>
 #include <../libstrongswan/ipsec/ipsec_types.h>
+#include <kernel/kernel_ipsec.h>
+#include <library.h>
 
-//#include <../libstrongswan/selectors/traffic_selector.h>
+// #include <../libstrongswan/selectors/traffic_selector.h>
 
-#define TEN_MS							10000
-#define IPV6_LEN    					16
-#define IPv4							0x4
-#define IPv6							0x6
-#define CRYPTO_SUCCESS					0x0
-#define ARW_CHK_FAIL 					0x1
-#define AUTH_CHK_FAIL 					0x2
-#define SOFT_AGING_THRESHOLD_CROSSED	0x3
-#define HARD_AGING_THRESHOLD_CROSSED	0x4
-#define BAD_PKT							0x5
-#define SEQ_NUM_ROLLOVER				0x6
-#define INVALID_SA_INDEX				0x7
-#define RESERVED						0x8
+#define TEN_MS 10000
+#define IPV6_LEN 16
+#define IPv4 0x4
+#define IPv6 0x6
+#define CRYPTO_SUCCESS 0x0
+#define ARW_CHK_FAIL 0x1
+#define AUTH_CHK_FAIL 0x2
+#define SOFT_AGING_THRESHOLD_CROSSED 0x3
+#define HARD_AGING_THRESHOLD_CROSSED 0x4
+#define BAD_PKT 0x5
+#define SEQ_NUM_ROLLOVER 0x6
+#define INVALID_SA_INDEX 0x7
+#define RESERVED 0x8
 
 #define KEY_BUF_MAX 120
 
@@ -31,124 +31,125 @@ typedef struct ipsec_offload_params_t ipsec_offload_params_t;
 typedef struct ipsec_offload_basic_params_t ipsec_offload_basic_params_t;
 typedef struct ipsec_offload_policy_t ipsec_offload_policy_t;
 
-typedef struct ipsec_offload_traffic_selector_t ipsec_offload_traffic_selector_t;
+typedef struct ipsec_offload_traffic_selector_t
+    ipsec_offload_traffic_selector_t;
 
 typedef struct address_chunk_t address_chunk_t;
 typedef struct ipsec_event_listener_t ipsec_event_listener_t;
 struct address_chunk_t {
-	int addr_family;
-	size_t addr_len;
-	char addr[16];
-};	
+  int addr_family;
+  size_t addr_len;
+  char addr[16];
+};
 struct ipsec_event_listener_t {
 
-	/**
-	 * Called when the lifetime of an IPsec SA expired
-	 *
-	 * @param protocol		protocol of the expired SA
-	 * @param spi			spi of the expired SA
-	 * @param dst			destination address of expired SA
-	 * @param hard			TRUE if this is a hard expire, FALSE otherwise
-	 */
-	void (*expire)(uint8_t protocol, uint32_t spi, host_t *dst, bool hard);
+  /**
+   * Called when the lifetime of an IPsec SA expired
+   *
+   * @param protocol		protocol of the expired SA
+   * @param spi			spi of the expired SA
+   * @param dst			destination address of expired SA
+   * @param hard			TRUE if this is a hard expire, FALSE
+   * otherwise
+   */
+  void (*expire)(uint8_t protocol, uint32_t spi, host_t *dst, bool hard);
 };
 /**
  * Private data of an traffic_selector_t object
  */
 struct ipsec_offload_traffic_selector_t {
 
-	/**
-	 * Type of address
-	 */
-	ts_type_t type;
+  /**
+   * Type of address
+   */
+  ts_type_t type;
 
-	/**
-	 * IP protocol (UDP, TCP, ICMP, ...)
-	 */
-	uint8_t protocol;
+  /**
+   * IP protocol (UDP, TCP, ICMP, ...)
+   */
+  uint8_t protocol;
 
-	/**
-	 * narrow this traffic selector to hosts external ip
-	 * if set, from and to have no meaning until set_address() is called
-	 */
-	bool dynamic;
+  /**
+   * narrow this traffic selector to hosts external ip
+   * if set, from and to have no meaning until set_address() is called
+   */
+  bool dynamic;
 
-	/**
-	 * subnet size in CIDR notation, 255 means a non-subnet address range
-	 */
-	uint8_t netbits;
+  /**
+   * subnet size in CIDR notation, 255 means a non-subnet address range
+   */
+  uint8_t netbits;
 
-	/**
-	 * begin of address range, network order
-	 */
-	char from[IPV6_LEN];
+  /**
+   * begin of address range, network order
+   */
+  char from[IPV6_LEN];
 
-	/**
-	 * end of address range, network order
-	 */
-	char to[IPV6_LEN];
+  /**
+   * end of address range, network order
+   */
+  char to[IPV6_LEN];
 
-	/**
-	 * begin of port range
-	 */
-	uint16_t from_port;
+  /**
+   * begin of port range
+   */
+  uint16_t from_port;
 
-	/**
-	 * end of port range
-	 */
-	uint16_t to_port;
+  /**
+   * end of port range
+   */
+  uint16_t to_port;
 };
 /**
  * Implementation of the ipsec interface intel ipsec plugin
  */
 struct ipsec_offload_t {
 
-	/**
-	 * Implements kernel_ipsec_t interface
-	 */
-	kernel_ipsec_t interface;
+  /**
+   * Implements kernel_ipsec_t interface
+   */
+  kernel_ipsec_t interface;
 };
 struct ipsec_offload_basic_params_t {
-	address_chunk_t src;
-	address_chunk_t dst;
-	uint32_t	spi;
-	uint32_t	offloadid; //This SA INDEX is the lower 3 bytes of RX SPI.
-	bool	config_done;
+  address_chunk_t src;
+  address_chunk_t dst;
+  uint32_t spi;
+  uint32_t offloadid; // This SA INDEX is the lower 3 bytes of RX SPI.
+  bool config_done;
 };
 
 struct ipsec_offload_policy_t {
-	policy_dir_t 	dir;
+  policy_dir_t dir;
 
-	ipsec_offload_traffic_selector_t  	src_ts;
-	ipsec_offload_traffic_selector_t  	dst_ts;
+  ipsec_offload_traffic_selector_t src_ts;
+  ipsec_offload_traffic_selector_t dst_ts;
 
-	ipsec_mode_t 	mode;
-	uint32_t   spi;
-
+  ipsec_mode_t mode;
+  uint32_t spi;
 };
 
 struct ipsec_offload_params_t {
-	ipsec_offload_basic_params_t	basic_params;
-	ipsec_offload_policy_t		policy;
-	uint32_t	replay_window;
-	uint32_t	salt;
-	uint16_t	enc_alg;
-	uint8_t	proto;
-	bool	esn;
-	bool	inbound;
-	size_t	key_len;
-	char   key[KEY_BUF_MAX];
-	lifetime_cfg_t	lifetime;
+  ipsec_offload_basic_params_t basic_params;
+  ipsec_offload_policy_t policy;
+  uint32_t replay_window;
+  uint32_t salt;
+  uint16_t enc_alg;
+  uint8_t proto;
+  bool esn;
+  bool inbound;
+  size_t key_len;
+  char key[KEY_BUF_MAX];
+  lifetime_cfg_t lifetime;
 };
 
 struct ipsec_offload_config_queue_data {
-	uint8_t proto;
-	uint8_t family;
-	uint32_t spi;
-	uint64_t cookie;
+  uint8_t proto;
+  uint8_t family;
+  uint32_t spi;
+  uint64_t cookie;
 #define IP_BUF 16
-	char sip[IP_BUF + 1];
-	char dip[IP_BUF + 1];
+  char sip[IP_BUF + 1];
+  char dip[IP_BUF + 1];
 };
 
 /**

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload.h
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload.h
@@ -42,7 +42,6 @@ struct address_chunk_t {
   char addr[16];
 };
 struct ipsec_event_listener_t {
-
   /**
    * Called when the lifetime of an IPsec SA expired
    *
@@ -52,13 +51,12 @@ struct ipsec_event_listener_t {
    * @param hard			TRUE if this is a hard expire, FALSE
    * otherwise
    */
-  void (*expire)(uint8_t protocol, uint32_t spi, host_t *dst, bool hard);
+  void (*expire)(uint8_t protocol, uint32_t spi, host_t* dst, bool hard);
 };
 /**
  * Private data of an traffic_selector_t object
  */
 struct ipsec_offload_traffic_selector_t {
-
   /**
    * Type of address
    */
@@ -104,7 +102,6 @@ struct ipsec_offload_traffic_selector_t {
  * Implementation of the ipsec interface intel ipsec plugin
  */
 struct ipsec_offload_t {
-
   /**
    * Implements kernel_ipsec_t interface
    */
@@ -114,7 +111,7 @@ struct ipsec_offload_basic_params_t {
   address_chunk_t src;
   address_chunk_t dst;
   uint32_t spi;
-  uint32_t offloadid; // This SA INDEX is the lower 3 bytes of RX SPI.
+  uint32_t offloadid;  // This SA INDEX is the lower 3 bytes of RX SPI.
   bool config_done;
 };
 
@@ -157,6 +154,6 @@ struct ipsec_offload_config_queue_data {
  *
  * @return			ipsec_offload_t instance
  */
-ipsec_offload_t *ipsec_offload_create();
+ipsec_offload_t* ipsec_offload_create();
 
 #endif /** IPSEC_OFFLOAD_H_ @}*/

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload_plugin.h
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload_plugin.h
@@ -1,4 +1,4 @@
-// Copyright 2000-2002, 2004-2017, 2021-2023 Intel Corporation
+// Copyright 2000-2002, 2004-2017, 2021-2023, 2025 Intel Corporation
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef IPSEC_INTEL_PLUGIN_H_
@@ -14,11 +14,10 @@ typedef struct ipsec_offload_plugin_t ipsec_offload_plugin_t;
  */
 struct ipsec_offload_plugin_t {
 
-	/**
-	 * implements plugin interface
-	 */
-	plugin_t plugin;
-
+  /**
+   * implements plugin interface
+   */
+  plugin_t plugin;
 };
 
 #endif /** IPSEC_INTEL_PLUGIN_H_ @}*/

--- a/ipsec_offload_plugin/ipsec_offload/ipsec_offload_plugin.h
+++ b/ipsec_offload_plugin/ipsec_offload/ipsec_offload_plugin.h
@@ -13,7 +13,6 @@ typedef struct ipsec_offload_plugin_t ipsec_offload_plugin_t;
  * plugin interface for ipsec offload plugin
  */
 struct ipsec_offload_plugin_t {
-
   /**
    * implements plugin interface
    */

--- a/ipsec_offload_plugin/ipsec_offload/log_plugin.h
+++ b/ipsec_offload_plugin/ipsec_offload/log_plugin.h
@@ -13,29 +13,29 @@
  *   Singleton Logger Class.
  */
 class CLogger {
-public:
+ public:
   /**
    *   Logs a message
    *   @param sMessage message to be logged.
    */
-  void Log(const std::string &sMessage);
+  void Log(const std::string& sMessage);
   /**
    *   Variable Length Logger function
    *   @param format string for the message to be logged.
    */
-  void Log(const char *format, ...);
+  void Log(const char* format, ...);
   /**
    *   << overloaded function to Logs a message
    *   @param sMessage message to be logged.
    */
-  CLogger &operator<<(const std::string &sMessage);
+  CLogger& operator<<(const std::string& sMessage);
   /**
    *   Funtion to create the instance of logger class.
    *   @return singleton object of Clogger class..
    */
-  static CLogger *GetLogger();
+  static CLogger* GetLogger();
 
-private:
+ private:
   /**
    *    Default constructor for the Logger class.
    */
@@ -43,13 +43,13 @@ private:
   /**
    *   copy constructor for the Logger class.
    */
-  CLogger(const CLogger &){}; // copy constructor is private
+  CLogger(const CLogger&){};  // copy constructor is private
   /**
    *   assignment operator for the Logger class.
    */
-  CLogger &operator=(const CLogger &) {
+  CLogger& operator=(const CLogger&) {
     return *this;
-  }; // assignment operator is private
+  };  // assignment operator is private
   /**
    *   Log file name.
    **/
@@ -57,7 +57,7 @@ private:
   /**
    *   Singleton logger class object pointer.
    **/
-  static CLogger *m_pThis;
+  static CLogger* m_pThis;
   /**
    *   Log file stream object.
    **/

--- a/ipsec_offload_plugin/ipsec_offload/log_plugin.h
+++ b/ipsec_offload_plugin/ipsec_offload/log_plugin.h
@@ -1,65 +1,66 @@
-// Copyright 2000-2002, 2004-2017, 2021-2023 Intel Corporation
+// Copyright 2000-2002, 2004-2017, 2021-2023, 2025 Intel Corporation
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef Plugin_CLogger_H
 #define Plugin_CLogger_H
+#include <cstdarg>
 #include <fstream>
 #include <iostream>
-#include <cstdarg>
 #include <string>
-//using namespace std;
+// using namespace std;
 #define LOGGER CLogger::GetLogger()
 /**
-*   Singleton Logger Class.
-*/
-class CLogger
-{
+ *   Singleton Logger Class.
+ */
+class CLogger {
 public:
-    /**
-    *   Logs a message
-    *   @param sMessage message to be logged.
-    */
-    void Log(const std::string& sMessage);
-    /**
-    *   Variable Length Logger function
-    *   @param format string for the message to be logged.
-    */
-    void Log(const char * format, ...);
-    /**
-    *   << overloaded function to Logs a message
-    *   @param sMessage message to be logged.
-    */
-    CLogger& operator<<(const std::string& sMessage);
-    /**
-    *   Funtion to create the instance of logger class.
-    *   @return singleton object of Clogger class..
-    */
-    static CLogger* GetLogger();
+  /**
+   *   Logs a message
+   *   @param sMessage message to be logged.
+   */
+  void Log(const std::string &sMessage);
+  /**
+   *   Variable Length Logger function
+   *   @param format string for the message to be logged.
+   */
+  void Log(const char *format, ...);
+  /**
+   *   << overloaded function to Logs a message
+   *   @param sMessage message to be logged.
+   */
+  CLogger &operator<<(const std::string &sMessage);
+  /**
+   *   Funtion to create the instance of logger class.
+   *   @return singleton object of Clogger class..
+   */
+  static CLogger *GetLogger();
+
 private:
-    /**
-    *    Default constructor for the Logger class.
-    */
-    CLogger();
-    /**
-    *   copy constructor for the Logger class.
-    */
-    CLogger(const CLogger&){};             // copy constructor is private
-    /**
-    *   assignment operator for the Logger class.
-    */
-    CLogger& operator=(const CLogger&){ return *this; };  // assignment operator is private
-    /**
-    *   Log file name.
-    **/
-    static const std::string m_sFileName;
-    /**
-    *   Singleton logger class object pointer.
-    **/
-    static CLogger* m_pThis;
-    /**
-    *   Log file stream object.
-    **/
-    static std::ofstream m_Logfile;
+  /**
+   *    Default constructor for the Logger class.
+   */
+  CLogger();
+  /**
+   *   copy constructor for the Logger class.
+   */
+  CLogger(const CLogger &){}; // copy constructor is private
+  /**
+   *   assignment operator for the Logger class.
+   */
+  CLogger &operator=(const CLogger &) {
+    return *this;
+  }; // assignment operator is private
+  /**
+   *   Log file name.
+   **/
+  static const std::string m_sFileName;
+  /**
+   *   Singleton logger class object pointer.
+   **/
+  static CLogger *m_pThis;
+  /**
+   *   Log file stream object.
+   **/
+  static std::ofstream m_Logfile;
 };
 #endif
-

--- a/ipsec_offload_plugin/ipsec_offload/utils.cc
+++ b/ipsec_offload_plugin/ipsec_offload/utils.cc
@@ -1,13 +1,14 @@
 // Copyright 2024-2025 Intel Corporation
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "utils.h"
+
 #include <google/protobuf/message.h>
 #include <google/protobuf/text_format.h>
 
 #include "log_plugin.h"
-#include "utils.h"
 
-int ReadFileToString(const std::string &filename, std::string *buffer) {
+int ReadFileToString(const std::string& filename, std::string* buffer) {
   if (!PathExists(filename)) {
     LOGGER->Log("ERROR: %s: Failed to open file: %s", __func__,
                 filename.c_str());
@@ -33,8 +34,8 @@ int ReadFileToString(const std::string &filename, std::string *buffer) {
   return 0;
 }
 
-int ParseProtoFromString(const std::string &text,
-                         ::google::protobuf::Message *message) {
+int ParseProtoFromString(const std::string& text,
+                         ::google::protobuf::Message* message) {
   if (!::google::protobuf::TextFormat::ParseFromString(text, message)) {
     LOGGER->Log("ERROR: %s Failed to parse proto from following string: %s",
                 __func__, text.c_str());
@@ -44,12 +45,11 @@ int ParseProtoFromString(const std::string &text,
   return 0;
 }
 
-int ReadProtoFromTextFile(const std::string &filename,
-                          ::google::protobuf::Message *message) {
+int ReadProtoFromTextFile(const std::string& filename,
+                          ::google::protobuf::Message* message) {
   std::string text;
   auto status = ReadFileToString(filename, &text);
-  if (status != 0)
-    return status;
+  if (status != 0) return status;
 
   status = ParseProtoFromString(text, message);
   return status;

--- a/ipsec_offload_plugin/ipsec_offload/utils.cc
+++ b/ipsec_offload_plugin/ipsec_offload/utils.cc
@@ -1,30 +1,27 @@
-// Copyright 2024 Intel Corporation
+// Copyright 2024-2025 Intel Corporation
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <google/protobuf/message.h>
 #include <google/protobuf/text_format.h>
 
-#include "utils.h"
 #include "log_plugin.h"
+#include "utils.h"
 
-int ReadFileToString(const std::string& filename,
-                     std::string* buffer) {
+int ReadFileToString(const std::string &filename, std::string *buffer) {
   if (!PathExists(filename)) {
-    LOGGER->Log("ERROR: %s: Failed to open file: %s",
-		    __func__, filename.c_str());
+    LOGGER->Log("ERROR: %s: Failed to open file: %s", __func__,
+                filename.c_str());
     return -1;
   }
   if (IsDir(filename)) {
-    LOGGER->Log("ERROR: %s: %s is a directory!",
-		    __func__, filename.c_str());
+    LOGGER->Log("ERROR: %s: %s is a directory!", __func__, filename.c_str());
     return -1;
   }
 
   std::ifstream infile;
   infile.open(filename.c_str());
   if (!infile.is_open()) {
-    LOGGER->Log("ERROR: %s when opening file %s",
-		    __func__, filename.c_str());
+    LOGGER->Log("ERROR: %s when opening file %s", __func__, filename.c_str());
     return -1;
   }
 
@@ -36,24 +33,24 @@ int ReadFileToString(const std::string& filename,
   return 0;
 }
 
-int ParseProtoFromString(const std::string& text,
-                        ::google::protobuf::Message* message) {
+int ParseProtoFromString(const std::string &text,
+                         ::google::protobuf::Message *message) {
   if (!::google::protobuf::TextFormat::ParseFromString(text, message)) {
     LOGGER->Log("ERROR: %s Failed to parse proto from following string: %s",
-		    __func__, text.c_str());
+                __func__, text.c_str());
     return -1;
   }
 
   return 0;
 }
 
-int ReadProtoFromTextFile(const std::string& filename,
-                         ::google::protobuf::Message* message) {
+int ReadProtoFromTextFile(const std::string &filename,
+                          ::google::protobuf::Message *message) {
   std::string text;
   auto status = ReadFileToString(filename, &text);
-  if(status != 0) 
+  if (status != 0)
     return status;
-  
+
   status = ParseProtoFromString(text, message);
   return status;
 }

--- a/ipsec_offload_plugin/ipsec_offload/utils.h
+++ b/ipsec_offload_plugin/ipsec_offload/utils.h
@@ -11,13 +11,13 @@
 #include <string>
 
 // Checks to see if a path exists
-inline bool PathExists(const std::string &path) {
+inline bool PathExists(const std::string& path) {
   struct stat stbuf;
   return (stat(path.c_str(), &stbuf) >= 0);
 }
 
 // Checks to see if a path is a dir
-inline bool IsDir(const std::string &path) {
+inline bool IsDir(const std::string& path) {
   struct stat stbuf;
   if (stat(path.c_str(), &stbuf) < 0) {
     return false;
@@ -26,13 +26,13 @@ inline bool IsDir(const std::string &path) {
 }
 
 // Reads the contents of a file to a string buffer
-int ReadFileToString(const std::string &filename, std::string *buffer);
+int ReadFileToString(const std::string& filename, std::string* buffer);
 
 // Parses a proto from a string
-int ParseProtoFromString(const std::string &text,
-                         ::google::protobuf::Message *message);
+int ParseProtoFromString(const std::string& text,
+                         ::google::protobuf::Message* message);
 
-int ReadProtoFromTextFile(const std::string &filename,
-                          ::google::protobuf::Message *message);
+int ReadProtoFromTextFile(const std::string& filename,
+                          ::google::protobuf::Message* message);
 
-#endif // IPSEC_PLUGIN_UTILS_H_
+#endif  // IPSEC_PLUGIN_UTILS_H_

--- a/ipsec_offload_plugin/ipsec_offload/utils.h
+++ b/ipsec_offload_plugin/ipsec_offload/utils.h
@@ -1,4 +1,4 @@
-// Copyright 2024 Intel Corporation
+// Copyright 2024-2025 Intel Corporation
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef IPSEC_PLUGIN_UTILS_H_
@@ -6,18 +6,18 @@
 
 #include <sys/stat.h>
 
-#include <ostream>
 #include <fstream>
+#include <ostream>
 #include <string>
 
 // Checks to see if a path exists
-inline bool PathExists(const std::string& path) {
+inline bool PathExists(const std::string &path) {
   struct stat stbuf;
   return (stat(path.c_str(), &stbuf) >= 0);
 }
 
 // Checks to see if a path is a dir
-inline bool IsDir(const std::string& path) {
+inline bool IsDir(const std::string &path) {
   struct stat stbuf;
   if (stat(path.c_str(), &stbuf) < 0) {
     return false;
@@ -26,14 +26,13 @@ inline bool IsDir(const std::string& path) {
 }
 
 // Reads the contents of a file to a string buffer
-int ReadFileToString(const std::string& filename,
-                    std::string* buffer);
+int ReadFileToString(const std::string &filename, std::string *buffer);
 
 // Parses a proto from a string
-int ParseProtoFromString(const std::string& text,
-                        ::google::protobuf::Message* message);
+int ParseProtoFromString(const std::string &text,
+                         ::google::protobuf::Message *message);
 
-int ReadProtoFromTextFile(const std::string& filename,
-                        ::google::protobuf::Message* message);
+int ReadProtoFromTextFile(const std::string &filename,
+                          ::google::protobuf::Message *message);
 
 #endif // IPSEC_PLUGIN_UTILS_H_


### PR DESCRIPTION
This CL does not introduce any functional changes.

The code format & styling in this repo does not follow any standard. In staying with the Google-style of clang-format used in other IPDK repos, adding the `.clang-format` file to this repo and applying the formatter to some of the files.

Most of the ipsec_offload_plugin/ipsec_offload cc src files are very large -- so applying the formatter results in very large diffs. In order to manage and make code review easier to digest, applying the clang-format only on the smaller files to start - the header files + utils.cc 
